### PR TITLE
Missing Instructions for Updating Default Values in Step 3 of CID Workshop

### DIFF
--- a/data-collection/deploy/account-collector.yaml
+++ b/data-collection/deploy/account-collector.yaml
@@ -263,7 +263,7 @@ Resources:
           MANAGEMENT_ACCOUNT_IDS: !Ref ManagementAccountID
           RESOURCE_PREFIX: !Ref ResourcePrefix
           BUCKET_NAME: !Ref DestinationBucket
-          PREDEF_ACCOUNT_LIST_KEY: "account-list/account-list"
+          PREDEF_ACCOUNT_LIST_KEY: "account-list/account-list "
           LINKED_ACCOUNT_LIST_KEY: "account-list/linked-account-list.json"
           PAYER_ACCOUNT_LIST_KEY: "account-list/payer-account-list.json"
           EXCLUDED_ACCOUNT_LIST_KEY: "account-list/excluded-linked-account-list.csv"


### PR DESCRIPTION
In this [step 3 of the CID workshop ](https://catalog.workshops.aws/awscid/en-US/customizations/data-collection-without-orgs#step-by-step-guide), the documentation states that the file should have a .csv or .json extension, but it doesn't mention updating the default values accordingly. This causes the program to fail.

The simplest solution would be to update the workshop documentation to include this step. I wasn’t sure where to provide this feedback, so I'm sharing it here since it's related.