### PR TITLE
fix: set timeout to 900s for the support cases collection lambda

### DIFF
--- a/data-collection/deploy/module-support-cases.yaml
+++ b/data-collection/deploy/module-support-cases.yaml
@@ -319,7 +319,7 @@ Resources:
               )
       Handler: 'index.lambda_handler'
       MemorySize: 2688
-      Timeout: 300
+      Timeout: 900
       Role: !GetAtt LambdaRole.Arn
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* increased the support case data collection lambda timeout to 900s 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
