### PR TITLE
deploy-in-linked-account.yaml updated with enhanced IAM security

### DIFF
--- a/data-collection/deploy/deploy-data-read-permissions.yaml
+++ b/data-collection/deploy/deploy-data-read-permissions.yaml
@@ -196,7 +196,6 @@ Resources:
         ResourcePrefix: !Ref ResourcePrefix
         IncludeComputeOptimizerModule: !Ref IncludeComputeOptimizerModule
         IncludeCostAnomalyModule: !Ref IncludeCostAnomalyModule
-        IncludeSupportCasesModule: !Ref IncludeSupportCasesModule
         IncludeRightsizingModule: !Ref IncludeRightsizingModule
         IncludeBackupModule: !Ref IncludeBackupModule
         IncludeHealthEventsModule: !Ref IncludeHealthEventsModule
@@ -216,7 +215,7 @@ Resources:
         IncludeInventoryCollectorModule: !Ref IncludeInventoryCollectorModule
         IncludeECSChargebackModule: !Ref IncludeECSChargebackModule
         IncludeRDSUtilizationModule: !Ref IncludeRDSUtilizationModule
-        IncludeEUCUtilizationModule: !Ref IncludeEUCUtilizationModule       
+        IncludeEUCUtilizationModule: !Ref IncludeEUCUtilizationModule
         IncludeBudgetsModule: !Ref IncludeBudgetsModule
         IncludeTransitGatewayModule: !Ref IncludeTransitGatewayModule
         IncludeServiceQuotasModule: !Ref IncludeServiceQuotasModule
@@ -252,7 +251,7 @@ Resources:
         - ParameterKey: IncludeRDSUtilizationModule
           ParameterValue: !Ref IncludeRDSUtilizationModule
         - ParameterKey: IncludeEUCUtilizationModule
-          ParameterValue: !Ref IncludeEUCUtilizationModule          
+          ParameterValue: !Ref IncludeEUCUtilizationModule
         - ParameterKey: IncludeBudgetsModule
           ParameterValue: !Ref IncludeBudgetsModule
         - ParameterKey: IncludeTransitGatewayModule

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -407,7 +407,6 @@ Resources:
           # CloudWatch metrics for WorkSpaces
           - Effect: "Allow"
             Action:
-                                     
               - "cloudwatch:GetMetricStatistics"
             Resource: !Sub "arn:${AWS::Partition}:cloudwatch:*:${AWS::AccountId}:*"
             Condition:

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -207,9 +207,6 @@ Resources:
               - "support:DescribeCases"
               - "support:DescribeCommunications"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            #Condition:
-            #  StringEquals:
-            #    "aws:AccountId": !Sub "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -323,9 +320,6 @@ Resources:
               - "ecs:ListClusters"
               - "ec2:DescribeRegions"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            Condition:
-              StringEquals:
-                "aws:AccountId": !Sub "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -353,9 +347,9 @@ Resources:
               - "ec2:DescribeRegions"
               - "cloudwatch:GetMetricStatistics"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            Condition:
-              StringEquals:
-                "aws:AccountId": !Sub "${AWS::AccountId}"
+            #Condition:
+            #  StringEquals:
+            #    "aws:AccountId": !Sub "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -363,7 +357,7 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-  # EUC Utilization policy - Split into resource-specific and global permissions
+  # EUC Utilization policy
   EUCUtilizationPolicy:
     Type: 'AWS::IAM::Policy'
     Condition: IncludeEUCUtilizationModulePolicy
@@ -377,12 +371,15 @@ Resources:
             Action:
               - "workspaces:DescribeWorkspaces"
               - "ec2:DescribeRegions"
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
+          - Effect: "Allow"
+            Action:
               - "cloudwatch:GetMetricStatistics"
               - "cloudwatch:ListMetrics"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
             Condition:
               StringEquals:
-                "aws:AccountId": !Sub "${AWS::AccountId}"
+                cloudwatch:namespace: AWS/WorkSpaces
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -390,7 +387,7 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-  # Transit Gateway policy - Split into resource-specific and global permissions
+  # Transit Gateway policy
   TransitGatewayPolicy:
     Type: 'AWS::IAM::Policy'
     Condition: IncludeTransitGatewayModulePolicy
@@ -399,22 +396,21 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          # Actions that support resource-level permissions
           - Effect: "Allow"
             Action:
               - "ec2:DescribeTransitGatewayAttachments"
-            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:transit-gateway-attachment/*"
-          # Actions that don't support resource-level permissions
+            Resource: '*' # Wildcard required as actions do not support resource-level permissions
           - Effect: "Allow"
             Action:
               - "cloudwatch:GetMetricStatistics"
-              - "cloudwatch:Describe*"
-              - "cloudwatch:Get*"
-              - "cloudwatch:List*"
+              #- "cloudwatch:Describe*"
+              #- "cloudwatch:Get*"
+              - "cloudwatch:GetMetricData"
+              #- "cloudwatch:List*"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
             #Condition:
             #  StringEquals:
-            #    "aws:AccountId": !Sub "${AWS::AccountId}"
+            #    cloudwatch:namespace: AWS/TransitGateway
       Roles:
         - Ref: LambdaRole
     Metadata:

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -371,7 +371,6 @@ Resources:
           # CloudWatch metrics for RDS
           - Effect: "Allow"
             Action:
-                                     
               - "cloudwatch:GetMetricStatistics"
             Resource: !Sub "arn:${AWS::Partition}:cloudwatch:*:${AWS::AccountId}:*"
             Condition:

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -1,6 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: CID Data Collection - Role for Linked Account v3.8.0
-
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -139,7 +138,6 @@ Outputs:
   LambdaRole:
     Description: For lambda to assume in cost account
     Value: !GetAtt LambdaRole.Arn
-
 Resources:
   LambdaRole:
     Type: AWS::IAM::Role
@@ -171,7 +169,6 @@ Resources:
         rules_to_suppress:
           - id: W28
             reason: "Role must have an explicit RoleName for traceability"
-
   # Trusted Advisor policy
   TAPolicy:
     Type: 'AWS::IAM::Policy'
@@ -186,6 +183,9 @@ Resources:
               - "support:DescribeTrustedAdvisorChecks"
               - "support:DescribeTrustedAdvisorCheckResult"
             Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Condition:
+              StringEquals:
+                "aws:AccountId": "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -193,7 +193,6 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-
   # Support Cases policy
   SupportCasesPolicy:
     Type: 'AWS::IAM::Policy'
@@ -208,6 +207,9 @@ Resources:
               - "support:DescribeCases"
               - "support:DescribeCommunications"
             Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Condition:
+              StringEquals:
+                "aws:AccountId": "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -215,7 +217,6 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-
   # Budgets policy
   BudgetsReadOnlyPolicy:
     Type: 'AWS::IAM::Policy'
@@ -233,7 +234,6 @@ Resources:
             Resource: !Sub "arn:${AWS::Partition}:budgets::${AWS::AccountId}:budget/*"
       Roles:
         - Ref: LambdaRole
-
   # Inventory Collector policy - Split into resource-specific and global permissions
   InventoryCollectorPolicy:
     Type: 'AWS::IAM::Policy'
@@ -246,27 +246,6 @@ Resources:
           # Actions that support resource-level permissions
           - Effect: "Allow"
             Action:
-              - "ec2:DescribeImages"
-            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:image/*"
-          - Effect: "Allow"
-            Action:
-              - "ec2:DescribeVolumes"
-            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:volume/*"
-          - Effect: "Allow"
-            Action:
-              - "ec2:DescribeSnapshots"
-            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:snapshot/*"
-          - Effect: "Allow"
-            Action:
-              - "ec2:DescribeInstances"
-            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:instance/*"
-          - Effect: "Allow"
-            Action:
-              - "ec2:DescribeVpcs"
-            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:vpc/*"
-          # RDS resources that support resource-level permissions
-          - Effect: "Allow"
-            Action:
               - "rds:DescribeDBClusters"
             Resource: !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:cluster:*"
           - Effect: "Allow"
@@ -277,18 +256,15 @@ Resources:
             Action:
               - "rds:DescribeDBSnapshots"
             Resource: !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:snapshot:*"
-          # ElasticSearch/OpenSearch resources
           - Effect: "Allow"
             Action:
               - "es:DescribeDomain"
               - "es:DescribeElasticsearchDomains"
             Resource: !Sub "arn:${AWS::Partition}:es:*:${AWS::AccountId}:domain/*"
-          # ElastiCache resources
           - Effect: "Allow"
             Action:
               - "elasticache:DescribeCacheClusters"
             Resource: !Sub "arn:${AWS::Partition}:elasticache:*:${AWS::AccountId}:cluster:*"
-          # EKS resources
           - Effect: "Allow"
             Action:
               - "eks:DescribeCluster"
@@ -297,26 +273,26 @@ Resources:
             Action:
               - "eks:DescribeNodegroup"
             Resource: !Sub "arn:${AWS::Partition}:eks:*:${AWS::AccountId}:nodegroup/*/*/*"
-          # Lambda resources
+          # Actions that require wildcard resources with account restriction
           - Effect: "Allow"
             Action:
-              - "lambda:ListFunctions"
-            Resource: !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:*"
-          # WorkSpaces resources
-          - Effect: "Allow"
-            Action:
-              - "workspaces:DescribeWorkspaces"
-              - "workspaces:DescribeWorkspaceDirectories"
-              - "workspaces:DescribeWorkspacesConnectionStatus"
-            Resource: !Sub "arn:${AWS::Partition}:workspaces:*:${AWS::AccountId}:workspace/*"
-          # Actions that don't support resource-level permissions
-          - Effect: "Allow"
-            Action:
+              - "ec2:DescribeImages"
+              - "ec2:DescribeVolumes"
+              - "ec2:DescribeSnapshots"
+              - "ec2:DescribeInstances"
+              - "ec2:DescribeVpcs"
               - "ec2:DescribeRegions"
               - "es:ListDomainNames"
               - "eks:ListClusters"
               - "eks:ListNodegroups"
+              - "lambda:ListFunctions"
+              - "workspaces:DescribeWorkspaces"
+              - "workspaces:DescribeWorkspaceDirectories"
+              - "workspaces:DescribeWorkspacesConnectionStatus"
             Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Condition:
+              StringEquals:
+                "aws:AccountId": "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -324,7 +300,6 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-
   # ECS Chargeback policy - Split into resource-specific and global permissions
   ECSChargebackPolicy:
     Type: 'AWS::IAM::Policy'
@@ -346,6 +321,9 @@ Resources:
               - "ecs:ListClusters"
               - "ec2:DescribeRegions"
             Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Condition:
+              StringEquals:
+                "aws:AccountId": "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -353,7 +331,6 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-
   # RDS Utilization policy - Split into resource-specific and global permissions
   RDSUtilizationPolicy:
     Type: 'AWS::IAM::Policy'
@@ -368,19 +345,15 @@ Resources:
             Action:
               - "rds:DescribeDBInstances"
             Resource: !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:db:*"
-          # CloudWatch metrics for RDS
-          - Effect: "Allow"
-            Action:
-              - "cloudwatch:GetMetricStatistics"
-            Resource: !Sub "arn:${AWS::Partition}:cloudwatch:*:${AWS::AccountId}:*"
-            Condition:
-              StringEquals:
-                "cloudwatch:namespace": "AWS/RDS"
           # Actions that don't support resource-level permissions
           - Effect: "Allow"
             Action:
               - "ec2:DescribeRegions"
+              - "cloudwatch:GetMetricStatistics"
             Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Condition:
+              StringEquals:
+                "aws:AccountId": "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -388,7 +361,6 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-
   # EUC Utilization policy - Split into resource-specific and global permissions
   EUCUtilizationPolicy:
     Type: 'AWS::IAM::Policy'
@@ -398,25 +370,17 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          # Actions that support resource-level permissions
-          - Effect: "Allow"
-            Action:
-              - "workspaces:DescribeWorkspaces"
-            Resource: !Sub "arn:${AWS::Partition}:workspaces:*:${AWS::AccountId}:workspace/*"
-          # CloudWatch metrics for WorkSpaces
-          - Effect: "Allow"
-            Action:
-              - "cloudwatch:GetMetricStatistics"
-            Resource: !Sub "arn:${AWS::Partition}:cloudwatch:*:${AWS::AccountId}:*"
-            Condition:
-              StringEquals:
-                "cloudwatch:namespace": "AWS/WorkSpaces"
           # Actions that don't support resource-level permissions
           - Effect: "Allow"
             Action:
+              - "workspaces:DescribeWorkspaces"
               - "ec2:DescribeRegions"
+              - "cloudwatch:GetMetricStatistics"
               - "cloudwatch:ListMetrics"
             Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Condition:
+              StringEquals:
+                "aws:AccountId": "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -424,7 +388,6 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-
   # Transit Gateway policy - Split into resource-specific and global permissions
   TransitGatewayPolicy:
     Type: 'AWS::IAM::Policy'
@@ -439,21 +402,17 @@ Resources:
             Action:
               - "ec2:DescribeTransitGatewayAttachments"
             Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:transit-gateway-attachment/*"
-          # CloudWatch metrics for Transit Gateway
-          - Effect: "Allow"
-            Action:
-              - "cloudwatch:GetMetricStatistics"
-            Resource: !Sub "arn:${AWS::Partition}:cloudwatch:*:${AWS::AccountId}:*"
-            Condition:
-              StringEquals:
-                "cloudwatch:namespace": "AWS/TransitGateway"
           # Actions that don't support resource-level permissions
           - Effect: "Allow"
             Action:
+              - "cloudwatch:GetMetricStatistics"
               - "cloudwatch:Describe*"
-                                 
+              - "cloudwatch:Get*"
               - "cloudwatch:List*"
             Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Condition:
+              StringEquals:
+                "aws:AccountId": "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -461,7 +420,6 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-
   # Service Quotas policy - Split into resource-specific and global permissions
   ServiceQuotasReadOnlyPolicy:
     Type: 'AWS::IAM::Policy'
@@ -481,6 +439,7 @@ Resources:
           # Actions that don't support resource-level permissions
           - Effect: "Allow"
             Action:
+              - "servicequotas:ListServices"
               - "rds:DescribeAccountAttributes"
               - "elasticloadbalancing:DescribeAccountLimits"
               - "dynamodb:DescribeLimits"
@@ -488,6 +447,9 @@ Resources:
               - "autoscaling:DescribeAccountLimits"
               - "route53:GetAccountLimit"
             Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Condition:
+              StringEquals:
+                "aws:AccountId": "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -205,7 +205,6 @@ Resources:
           - Effect: "Allow"
             Action:
               - "budgets:ViewBudget"
-              - "budgets:DescribeBudgets"
               - "budgets:ListTagsForResource"
             Resource: !Sub "arn:${AWS::Partition}:budgets::${AWS::AccountId}:budget/*"
       Roles:

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -337,7 +337,6 @@ Resources:
           # Actions that support resource-level permissions
           - Effect: "Allow"
             Action:
-                                  
               - "ecs:DescribeServices"
             Resource: !Sub "arn:${AWS::Partition}:ecs:*:${AWS::AccountId}:service/*"
           # Actions that don't support resource-level permissions

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -183,9 +183,6 @@ Resources:
               - "support:DescribeTrustedAdvisorChecks"
               - "support:DescribeTrustedAdvisorCheckResult"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            #Condition:
-            #  StringEquals:
-            #   "aws:AccountId": !Sub "${AWS::AccountId}" # DescribeTrustedAdvisorChecks DescribeTrustedAdvisorCheckResult do not support conditions
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -289,9 +286,6 @@ Resources:
               - "workspaces:DescribeWorkspaceDirectories"
               - "workspaces:DescribeWorkspacesConnectionStatus"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            #Condition:
-            #  StringEquals:
-            #    "aws:AccountId": !Sub "${AWS::AccountId}" ## not supported es:ListDomainNames ec2:DescribeSnapshots "ec2:DescribeVolumes
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -345,11 +339,14 @@ Resources:
           - Effect: "Allow"
             Action:
               - "ec2:DescribeRegions"
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
+          - Effect: "Allow"
+            Action:
               - "cloudwatch:GetMetricStatistics"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            #Condition:
-            #  StringEquals:
-            #    "aws:AccountId": !Sub "${AWS::AccountId}"
+            Condition:
+              StringEquals:
+                cloudwatch:namespace: AWS/WorkSpaces
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -375,7 +372,7 @@ Resources:
           - Effect: "Allow"
             Action:
               - "cloudwatch:GetMetricStatistics"
-              - "cloudwatch:ListMetrics"
+#              - "cloudwatch:ListMetrics"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
             Condition:
               StringEquals:
@@ -403,14 +400,8 @@ Resources:
           - Effect: "Allow"
             Action:
               - "cloudwatch:GetMetricStatistics"
-              #- "cloudwatch:Describe*"
-              #- "cloudwatch:Get*"
-              - "cloudwatch:GetMetricData"
-              #- "cloudwatch:List*"
+#              - "cloudwatch:GetMetricData"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            #Condition:
-            #  StringEquals:
-            #    cloudwatch:namespace: AWS/TransitGateway
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -440,9 +431,6 @@ Resources:
               - "autoscaling:DescribeAccountLimits"
               - "route53:GetAccountLimit"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            #Condition:
-            #  StringEquals:
-            #    "aws:AccountId": !Sub "${AWS::AccountId}" # Not supported by "servicequotas:ListRequestedServiceQuotaChangeHistory"
       Roles:
         - Ref: LambdaRole
     Metadata:

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -343,10 +343,8 @@ Resources:
           - Effect: "Allow"
             Action:
               - "cloudwatch:GetMetricStatistics"
+              - "cloudwatch:GetMetricData"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            Condition:
-              StringEquals:
-                cloudwatch:namespace: AWS/WorkSpaces
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -372,11 +370,8 @@ Resources:
           - Effect: "Allow"
             Action:
               - "cloudwatch:GetMetricStatistics"
-#              - "cloudwatch:ListMetrics"
+              - "cloudwatch:GetMetricData"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
-            Condition:
-              StringEquals:
-                cloudwatch:namespace: AWS/WorkSpaces
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -400,7 +395,7 @@ Resources:
           - Effect: "Allow"
             Action:
               - "cloudwatch:GetMetricStatistics"
-#              - "cloudwatch:GetMetricData"
+              - "cloudwatch:GetMetricData"
             Resource: "*" # Wildcard required as actions do not support resource-level permissions
       Roles:
         - Ref: LambdaRole

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -182,10 +182,10 @@ Resources:
             Action:
               - "support:DescribeTrustedAdvisorChecks"
               - "support:DescribeTrustedAdvisorCheckResult"
-            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
-            Condition:
-              StringEquals:
-                "aws:AccountId": "${AWS::AccountId}"
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
+            #Condition:
+            #  StringEquals:
+            #   "aws:AccountId": !Sub "${AWS::AccountId}" # DescribeTrustedAdvisorChecks DescribeTrustedAdvisorCheckResult do not support conditions
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -206,10 +206,10 @@ Resources:
             Action:
               - "support:DescribeCases"
               - "support:DescribeCommunications"
-            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
-            Condition:
-              StringEquals:
-                "aws:AccountId": "${AWS::AccountId}"
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
+            #Condition:
+            #  StringEquals:
+            #    "aws:AccountId": !Sub "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -255,7 +255,9 @@ Resources:
           - Effect: "Allow"
             Action:
               - "rds:DescribeDBSnapshots"
-            Resource: !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:snapshot:*"
+            Resource:
+              - !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:snapshot:*"
+              - !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:db:*"
           - Effect: "Allow"
             Action:
               - "es:DescribeDomain"
@@ -289,10 +291,10 @@ Resources:
               - "workspaces:DescribeWorkspaces"
               - "workspaces:DescribeWorkspaceDirectories"
               - "workspaces:DescribeWorkspacesConnectionStatus"
-            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
-            Condition:
-              StringEquals:
-                "aws:AccountId": "${AWS::AccountId}"
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
+            #Condition:
+            #  StringEquals:
+            #    "aws:AccountId": !Sub "${AWS::AccountId}" ## not supported es:ListDomainNames ec2:DescribeSnapshots "ec2:DescribeVolumes
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -320,10 +322,10 @@ Resources:
               - "ecs:ListServices"
               - "ecs:ListClusters"
               - "ec2:DescribeRegions"
-            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
             Condition:
               StringEquals:
-                "aws:AccountId": "${AWS::AccountId}"
+                "aws:AccountId": !Sub "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -350,10 +352,10 @@ Resources:
             Action:
               - "ec2:DescribeRegions"
               - "cloudwatch:GetMetricStatistics"
-            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
             Condition:
               StringEquals:
-                "aws:AccountId": "${AWS::AccountId}"
+                "aws:AccountId": !Sub "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -377,10 +379,10 @@ Resources:
               - "ec2:DescribeRegions"
               - "cloudwatch:GetMetricStatistics"
               - "cloudwatch:ListMetrics"
-            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
             Condition:
               StringEquals:
-                "aws:AccountId": "${AWS::AccountId}"
+                "aws:AccountId": !Sub "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -409,10 +411,10 @@ Resources:
               - "cloudwatch:Describe*"
               - "cloudwatch:Get*"
               - "cloudwatch:List*"
-            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
-            Condition:
-              StringEquals:
-                "aws:AccountId": "${AWS::AccountId}"
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
+            #Condition:
+            #  StringEquals:
+            #    "aws:AccountId": !Sub "${AWS::AccountId}"
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -420,7 +422,7 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
-  # Service Quotas policy - Split into resource-specific and global permissions
+  # Service Quotas policy
   ServiceQuotasReadOnlyPolicy:
     Type: 'AWS::IAM::Policy'
     Condition: IncludeServiceQuotasModulePolicy
@@ -429,16 +431,11 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
-          # Actions that support resource-level permissions
           - Effect: "Allow"
             Action:
               - "servicequotas:ListRequestedServiceQuotaChangeHistory"
               - "servicequotas:GetServiceQuota"
               - "servicequotas:GetAWSDefaultServiceQuota"
-            Resource: !Sub "arn:${AWS::Partition}:servicequotas:*:${AWS::AccountId}:*"
-          # Actions that don't support resource-level permissions
-          - Effect: "Allow"
-            Action:
               - "servicequotas:ListServices"
               - "rds:DescribeAccountAttributes"
               - "elasticloadbalancing:DescribeAccountLimits"
@@ -446,10 +443,10 @@ Resources:
               - "cloudformation:DescribeAccountLimits"
               - "autoscaling:DescribeAccountLimits"
               - "route53:GetAccountLimit"
-            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
-            Condition:
-              StringEquals:
-                "aws:AccountId": "${AWS::AccountId}"
+            Resource: "*" # Wildcard required as actions do not support resource-level permissions
+            #Condition:
+            #  StringEquals:
+            #    "aws:AccountId": !Sub "${AWS::AccountId}" # Not supported by "servicequotas:ListRequestedServiceQuotaChangeHistory"
       Roles:
         - Ref: LambdaRole
     Metadata:

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: CID Data Collection - Role for Linked Account v3.9.0
+Description: CID Data Collection - Role for Linked Account v3.8.0
 
 Metadata:
   AWS::CloudFormation::Interface:

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -1,5 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: CID Data Collection - Role for Linked Account v3.8.0
+Description: CID Data Collection - Role for Linked Account v3.9.0
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -39,7 +40,7 @@ Metadata:
       IncludeRDSUtilizationModule:
         default: 'Include RDS Utilization Data Collection Module'
       IncludeEUCUtilizationModule:
-        default: 'Include WorkSpaces Utilization Data Collection Module'     
+        default: 'Include WorkSpaces Utilization Data Collection Module'
       IncludeBudgetsModule:
         default: 'Include Budgets Collection Module'
       IncludeTransitGatewayModule:
@@ -88,7 +89,7 @@ Parameters:
     Type: String
     Description: Collects WorkSpaces CloudWatch metrics from your accounts
     AllowedValues: ['yes', 'no']
-    Default: 'no' 
+    Default: 'no'
   IncludeBudgetsModule:
     Type: String
     Description: Collects budgets from your accounts
@@ -138,6 +139,7 @@ Outputs:
   LambdaRole:
     Description: For lambda to assume in cost account
     Value: !GetAtt LambdaRole.Arn
+
 Resources:
   LambdaRole:
     Type: AWS::IAM::Role
@@ -169,6 +171,8 @@ Resources:
         rules_to_suppress:
           - id: W28
             reason: "Role must have an explicit RoleName for traceability"
+
+  # Trusted Advisor policy
   TAPolicy:
     Type: 'AWS::IAM::Policy'
     Condition: IncludeTAModulePolicy
@@ -181,7 +185,7 @@ Resources:
             Action:
               - "support:DescribeTrustedAdvisorChecks"
               - "support:DescribeTrustedAdvisorCheckResult"
-            Resource: "*" ## Policy is used for scanning of a wide range of resources
+            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -189,6 +193,8 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
+
+  # Support Cases policy
   SupportCasesPolicy:
     Type: 'AWS::IAM::Policy'
     Condition: IncludeSupportCasesModulePolicy
@@ -201,7 +207,7 @@ Resources:
             Action:
               - "support:DescribeCases"
               - "support:DescribeCommunications"
-            Resource: "*" ## Policy is used for scanning of a wide range of resources
+            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -209,6 +215,8 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
+
+  # Budgets policy
   BudgetsReadOnlyPolicy:
     Type: 'AWS::IAM::Policy'
     Condition: IncludeBudgetsModulePolicy
@@ -222,9 +230,11 @@ Resources:
               - "budgets:ViewBudget"
               - "budgets:DescribeBudgets"
               - "budgets:ListTagsForResource"
-            Resource: !Sub "arn:${AWS::Partition}:budgets::*:budget/*"
+            Resource: !Sub "arn:${AWS::Partition}:budgets::${AWS::AccountId}:budget/*"
       Roles:
         - Ref: LambdaRole
+
+  # Inventory Collector policy - Split into resource-specific and global permissions
   InventoryCollectorPolicy:
     Type: 'AWS::IAM::Policy'
     Condition: IncludeInventoryCollectorModulePolicy
@@ -233,101 +243,80 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
+          # Actions that support resource-level permissions
           - Effect: "Allow"
             Action:
               - "ec2:DescribeImages"
+            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:image/*"
+          - Effect: "Allow"
+            Action:
               - "ec2:DescribeVolumes"
+            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:volume/*"
+          - Effect: "Allow"
+            Action:
               - "ec2:DescribeSnapshots"
-              - "ec2:DescribeRegions"
+            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:snapshot/*"
+          - Effect: "Allow"
+            Action:
               - "ec2:DescribeInstances"
+            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:instance/*"
+          - Effect: "Allow"
+            Action:
               - "ec2:DescribeVpcs"
+            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:vpc/*"
+          # RDS resources that support resource-level permissions
+          - Effect: "Allow"
+            Action:
               - "rds:DescribeDBClusters"
+            Resource: !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:cluster:*"
+          - Effect: "Allow"
+            Action:
               - "rds:DescribeDBInstances"
+            Resource: !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:db:*"
+          - Effect: "Allow"
+            Action:
               - "rds:DescribeDBSnapshots"
-              - "es:ListDomainNames"
+            Resource: !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:snapshot:*"
+          # ElasticSearch/OpenSearch resources
+          - Effect: "Allow"
+            Action:
               - "es:DescribeDomain"
               - "es:DescribeElasticsearchDomains"
+            Resource: !Sub "arn:${AWS::Partition}:es:*:${AWS::AccountId}:domain/*"
+          # ElastiCache resources
+          - Effect: "Allow"
+            Action:
               - "elasticache:DescribeCacheClusters"
-              - "eks:ListClusters"
+            Resource: !Sub "arn:${AWS::Partition}:elasticache:*:${AWS::AccountId}:cluster:*"
+          # EKS resources
+          - Effect: "Allow"
+            Action:
               - "eks:DescribeCluster"
-              - "eks:ListNodegroups"
+            Resource: !Sub "arn:${AWS::Partition}:eks:*:${AWS::AccountId}:cluster/*"
+          - Effect: "Allow"
+            Action:
               - "eks:DescribeNodegroup"
+            Resource: !Sub "arn:${AWS::Partition}:eks:*:${AWS::AccountId}:nodegroup/*/*/*"
+          # Lambda resources
+          - Effect: "Allow"
+            Action:
               - "lambda:ListFunctions"
+            Resource: !Sub "arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:*"
+          # WorkSpaces resources
+          - Effect: "Allow"
+            Action:
               - "workspaces:DescribeWorkspaces"
               - "workspaces:DescribeWorkspaceDirectories"
-              - "workspaces:DescribeWorkspacesConnectionStatus"            
-            Resource: "*" ## Policy is used for scanning of a wide range of resources
-      Roles:
-        - Ref: LambdaRole
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W12
-            reason: "Policy is used for scanning of a wide range of resources"
-  ECSChargebackPolicy:
-    Type: 'AWS::IAM::Policy'
-    Condition: IncludeECSChargebackModulePolicy
-    Properties:
-      PolicyName: ECSChargebackPolicy
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Action:
-              - "ecs:ListServices"
-              - "ecs:DescribeServices"
-              - "ecs:ListClusters"
-              - "ec2:DescribeRegions"
-            Resource: "*" ## Policy is used for scanning of a wide range of resources
-      Roles:
-        - Ref: LambdaRole
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W12
-            reason: "Policy is used for scanning of a wide range of resources"
-  RDSUtilizationPolicy:
-    Type: 'AWS::IAM::Policy'
-    Condition: IncludeRDSUtilizationModulePolicy
-    Properties:
-      PolicyName: RDSUtilizationPolicy
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Action:
-              - "rds:DescribeDBInstances"
-            Resource: "*"  ## Policy is used for scanning of a wide range of resources
+              - "workspaces:DescribeWorkspacesConnectionStatus"
+            Resource: !Sub "arn:${AWS::Partition}:workspaces:*:${AWS::AccountId}:workspace/*"
+          # Actions that don't support resource-level permissions
           - Effect: "Allow"
             Action:
               - "ec2:DescribeRegions"
-              - "cloudwatch:GetMetricStatistics"
-            Resource: "*" ## Policy is used for scanning of a wide range of resources
-      Roles:
-        - Ref: LambdaRole
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W12
-            reason: "Policy is used for scanning of a wide range of resources"
-  EUCUtilizationPolicy:
-    Type: 'AWS::IAM::Policy'
-    Condition: IncludeEUCUtilizationModulePolicy
-    Properties:
-      PolicyName: EUCUtilizationPolicy
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Action:
-              - "workspaces:DescribeWorkspaces"
-            Resource: "*"  ## Policy is used for scanning of a wide range of resources
-          - Effect: "Allow"
-            Action:
-              - "ec2:DescribeRegions"
-              - "cloudwatch:GetMetricStatistics"
-              - "cloudwatch:ListMetrics"
-            Resource: "*" ## Policy is used for scanning of a wide range of resources
+              - "es:ListDomainNames"
+              - "eks:ListClusters"
+              - "eks:ListNodegroups"
+            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -336,6 +325,110 @@ Resources:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
 
+  # ECS Chargeback policy - Split into resource-specific and global permissions
+  ECSChargebackPolicy:
+    Type: 'AWS::IAM::Policy'
+    Condition: IncludeECSChargebackModulePolicy
+    Properties:
+      PolicyName: ECSChargebackPolicy
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # Actions that support resource-level permissions
+          - Effect: "Allow"
+            Action:
+                                  
+              - "ecs:DescribeServices"
+            Resource: !Sub "arn:${AWS::Partition}:ecs:*:${AWS::AccountId}:service/*"
+          # Actions that don't support resource-level permissions
+          - Effect: "Allow"
+            Action:
+              - "ecs:ListServices"
+              - "ecs:ListClusters"
+              - "ec2:DescribeRegions"
+            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+      Roles:
+        - Ref: LambdaRole
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W12
+            reason: "Policy is used for scanning of a wide range of resources"
+
+  # RDS Utilization policy - Split into resource-specific and global permissions
+  RDSUtilizationPolicy:
+    Type: 'AWS::IAM::Policy'
+    Condition: IncludeRDSUtilizationModulePolicy
+    Properties:
+      PolicyName: RDSUtilizationPolicy
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # Actions that support resource-level permissions
+          - Effect: "Allow"
+            Action:
+              - "rds:DescribeDBInstances"
+            Resource: !Sub "arn:${AWS::Partition}:rds:*:${AWS::AccountId}:db:*"
+          # CloudWatch metrics for RDS
+          - Effect: "Allow"
+            Action:
+                                     
+              - "cloudwatch:GetMetricStatistics"
+            Resource: !Sub "arn:${AWS::Partition}:cloudwatch:*:${AWS::AccountId}:*"
+            Condition:
+              StringEquals:
+                "cloudwatch:namespace": "AWS/RDS"
+          # Actions that don't support resource-level permissions
+          - Effect: "Allow"
+            Action:
+              - "ec2:DescribeRegions"
+            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+      Roles:
+        - Ref: LambdaRole
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W12
+            reason: "Policy is used for scanning of a wide range of resources"
+
+  # EUC Utilization policy - Split into resource-specific and global permissions
+  EUCUtilizationPolicy:
+    Type: 'AWS::IAM::Policy'
+    Condition: IncludeEUCUtilizationModulePolicy
+    Properties:
+      PolicyName: EUCUtilizationPolicy
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          # Actions that support resource-level permissions
+          - Effect: "Allow"
+            Action:
+              - "workspaces:DescribeWorkspaces"
+            Resource: !Sub "arn:${AWS::Partition}:workspaces:*:${AWS::AccountId}:workspace/*"
+          # CloudWatch metrics for WorkSpaces
+          - Effect: "Allow"
+            Action:
+                                     
+              - "cloudwatch:GetMetricStatistics"
+            Resource: !Sub "arn:${AWS::Partition}:cloudwatch:*:${AWS::AccountId}:*"
+            Condition:
+              StringEquals:
+                "cloudwatch:namespace": "AWS/WorkSpaces"
+          # Actions that don't support resource-level permissions
+          - Effect: "Allow"
+            Action:
+              - "ec2:DescribeRegions"
+              - "cloudwatch:ListMetrics"
+            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
+      Roles:
+        - Ref: LambdaRole
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W12
+            reason: "Policy is used for scanning of a wide range of resources"
+
+  # Transit Gateway policy - Split into resource-specific and global permissions
   TransitGatewayPolicy:
     Type: 'AWS::IAM::Policy'
     Condition: IncludeTransitGatewayModulePolicy
@@ -344,13 +437,26 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
+          # Actions that support resource-level permissions
           - Effect: "Allow"
             Action:
               - "ec2:DescribeTransitGatewayAttachments"
+            Resource: !Sub "arn:${AWS::Partition}:ec2:*:${AWS::AccountId}:transit-gateway-attachment/*"
+          # CloudWatch metrics for Transit Gateway
+          - Effect: "Allow"
+            Action:
+              - "cloudwatch:GetMetricStatistics"
+            Resource: !Sub "arn:${AWS::Partition}:cloudwatch:*:${AWS::AccountId}:*"
+            Condition:
+              StringEquals:
+                "cloudwatch:namespace": "AWS/TransitGateway"
+          # Actions that don't support resource-level permissions
+          - Effect: "Allow"
+            Action:
               - "cloudwatch:Describe*"
-              - "cloudwatch:Get*"
+                                 
               - "cloudwatch:List*"
-            Resource: "*" ## Policy is used for scanning of a wide range of resources
+            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
       Roles:
         - Ref: LambdaRole
     Metadata:
@@ -358,6 +464,8 @@ Resources:
         rules_to_suppress:
           - id: W12
             reason: "Policy is used for scanning of a wide range of resources"
+
+  # Service Quotas policy - Split into resource-specific and global permissions
   ServiceQuotasReadOnlyPolicy:
     Type: 'AWS::IAM::Policy'
     Condition: IncludeServiceQuotasModulePolicy
@@ -366,18 +474,23 @@ Resources:
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
+          # Actions that support resource-level permissions
           - Effect: "Allow"
             Action:
               - "servicequotas:ListRequestedServiceQuotaChangeHistory"
               - "servicequotas:GetServiceQuota"
               - "servicequotas:GetAWSDefaultServiceQuota"
+            Resource: !Sub "arn:${AWS::Partition}:servicequotas:*:${AWS::AccountId}:*"
+          # Actions that don't support resource-level permissions
+          - Effect: "Allow"
+            Action:
               - "rds:DescribeAccountAttributes"
               - "elasticloadbalancing:DescribeAccountLimits"
               - "dynamodb:DescribeLimits"
               - "cloudformation:DescribeAccountLimits"
               - "autoscaling:DescribeAccountLimits"
               - "route53:GetAccountLimit"
-            Resource: "*" ## Policy is used for scanning a wide range of resources. All service quotas in this case. All of them.
+            Resource: "*" ## Wildcard required as actions do not support resource-level permissions
       Roles:
         - Ref: LambdaRole
     Metadata:

--- a/data-collection/deploy/deploy-in-linked-account.yaml
+++ b/data-collection/deploy/deploy-in-linked-account.yaml
@@ -106,33 +106,15 @@ Parameters:
     Default: 'no'
 
 Conditions:
-  IncludeTAModulePolicy: !Equals
-    - !Ref IncludeTAModule
-    - "yes"
-  IncludeSupportCasesModulePolicy: !Equals
-    - !Ref IncludeSupportCasesModule
-    - "yes"
-  IncludeInventoryCollectorModulePolicy: !Equals
-    - !Ref IncludeInventoryCollectorModule
-    - "yes"
-  IncludeECSChargebackModulePolicy: !Equals
-    - !Ref IncludeECSChargebackModule
-    - "yes"
-  IncludeRDSUtilizationModulePolicy: !Equals
-    - !Ref IncludeRDSUtilizationModule
-    - "yes"
-  IncludeEUCUtilizationModulePolicy: !Equals
-    - !Ref IncludeEUCUtilizationModule
-    - "yes"
-  IncludeBudgetsModulePolicy: !Equals
-    - !Ref IncludeBudgetsModule
-    - "yes"
-  IncludeTransitGatewayModulePolicy: !Equals
-    - !Ref IncludeTransitGatewayModule
-    - "yes"
-  IncludeServiceQuotasModulePolicy: !Equals
-    - !Ref IncludeServiceQuotasModule
-    - "yes"
+  IncludeTAModulePolicy:                 !Equals [!Ref IncludeTAModule, "yes"]
+  IncludeSupportCasesModulePolicy:       !Equals [!Ref IncludeSupportCasesModule, "yes"]
+  IncludeInventoryCollectorModulePolicy: !Equals [!Ref IncludeInventoryCollectorModule, "yes"]
+  IncludeECSChargebackModulePolicy:      !Equals [!Ref IncludeECSChargebackModule, "yes"]
+  IncludeRDSUtilizationModulePolicy:     !Equals [!Ref IncludeRDSUtilizationModule, "yes"]
+  IncludeEUCUtilizationModulePolicy:     !Equals [!Ref IncludeEUCUtilizationModule, "yes"]
+  IncludeBudgetsModulePolicy:            !Equals [!Ref IncludeBudgetsModule, "yes"]
+  IncludeTransitGatewayModulePolicy:     !Equals [!Ref IncludeTransitGatewayModule, "yes"]
+  IncludeServiceQuotasModulePolicy:      !Equals [!Ref IncludeServiceQuotasModule, "yes"]
 
 Outputs:
   LambdaRole:

--- a/data-collection/deploy/deploy-in-management-account.yaml
+++ b/data-collection/deploy/deploy-in-management-account.yaml
@@ -15,7 +15,6 @@ Metadata:
           - IncludeBackupModule
           - IncludeComputeOptimizerModule
           - IncludeCostAnomalyModule
-          - IncludeSupportCasesModule
           - IncludeHealthEventsModule
           - IncludeRightsizingModule
           - IncludeLicenseManagerModule
@@ -31,8 +30,6 @@ Metadata:
         default: "Include AWS Compute Optimizer Data Collection Module"
       IncludeCostAnomalyModule:
         default: "Include Cost Anomalies Data Collection Module"
-      IncludeSupportCasesModule:
-        default: "Include Support Cases Data Collection Module"
       IncludeRightsizingModule:
         default: "Include Rightsizing Recommendations Data Collection Module"
       IncludeBackupModule:
@@ -65,11 +62,6 @@ Parameters:
     Description: "Collects AWS Cost Explorer Cost Anomalies Recommendations"
     AllowedValues: ['yes', 'no']
     Default: 'no'
-  IncludeSupportCasesModule:
-    Type: String
-    Description: "Collects AWS Support Cases data"
-    AllowedValues: ['yes', 'no']
-    Default: 'no'
   IncludeRightsizingModule:
     Type: String
     Description: "Collects AWS Cost Explorer Rightsizing Recommendations"
@@ -99,7 +91,6 @@ Parameters:
 Conditions:
   EnableComputeOptimizerModule: !Equals [!Ref IncludeComputeOptimizerModule, "yes"]
   EnableCostAnomaliesModule: !Equals [!Ref IncludeCostAnomalyModule, "yes"]
-  EnableSupportCasesModule: !Equals [!Ref IncludeSupportCasesModule, "yes"]
   EnableRightsizingModule: !Equals [!Ref IncludeRightsizingModule, "yes"]
   EnableBackupModule: !Equals [!Ref IncludeBackupModule, "yes"]
   EnableHealthEventsModule: !Equals [!Ref IncludeHealthEventsModule, "yes"]
@@ -206,26 +197,6 @@ Resources:
           - Effect: "Allow"
             Action:
               - "ce:GetAnomalies"
-            Resource: "*"
-      Roles:
-        - Ref: LambdaRole
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W12
-            reason: "Policy is used for scanning of a wide range of resources"
-  SupportCasesPolicy:
-    Type: "AWS::IAM::Policy"
-    Condition: EnableSupportCasesModule
-    Properties:
-      PolicyName: SupportCasesPolicy
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Action:
-              - "support:DescribeCases"
-              - "support:DescribeCommunications"
             Resource: "*"
       Roles:
         - Ref: LambdaRole

--- a/data-collection/deploy/deploy-in-management-account.yaml
+++ b/data-collection/deploy/deploy-in-management-account.yaml
@@ -313,6 +313,11 @@ Resources:
               - "rds:DescribeDBInstances"
               - "rds:DescribeDBClusters"
             Resource: "*"
+          - Effect: "Allow"
+            Action:
+              - "compute-optimizer:ExportIdleRecommendations"
+              - "compute-optimizer:GetIdleRecommendations"
+            Resource: "*"
       Roles:
         - Ref: LambdaRole
     Metadata:

--- a/data-collection/deploy/module-compute-optimizer.yaml
+++ b/data-collection/deploy/module-compute-optimizer.yaml
@@ -126,7 +126,6 @@ Resources:
                   - s3:DeleteBucket
                   - s3:ListBucket
                   - s3:Put*
-                  - s3:Set*
                   - s3:Get*
                   - s3:Replicate*
                   - s3:DeleteBucketPolicy

--- a/data-collection/deploy/module-workspaces-metrics.yaml
+++ b/data-collection/deploy/module-workspaces-metrics.yaml
@@ -68,7 +68,7 @@ Outputs:
     Value: !GetAtt ModuleStepFunction.Arn
 
 Conditions:
-  NeedDataBucketsKms: !Not[!Equals[!Ref DataBucketsKmsKeysArns, '']]
+  NeedDataBucketsKms: !Not [ !Equals [ !Ref DataBucketsKmsKeysArns, '' ] ]
 
 Resources:
   WorkSpacesMetricsTable:

--- a/data-collection/deploy/source/step-functions/awsfeeds-state-machine-v1.json
+++ b/data-collection/deploy/source/step-functions/awsfeeds-state-machine-v1.json
@@ -48,7 +48,7 @@
     },
     "Wait for Crawler to be ready": {
       "Type": "Wait",
-      "Seconds": 60,
+      "Seconds": 15,
       "Next": "GetCrawler1"
     },
     "StartCrawler": {
@@ -61,7 +61,7 @@
     },
     "Wait for Crawler Execution": {
       "Type": "Wait",
-      "Seconds": 60,
+      "Seconds": 15,
       "Next": "GetCrawler2"
     },
     "GetCrawler2": {

--- a/test/test_from_scratch.py
+++ b/test/test_from_scratch.py
@@ -125,9 +125,9 @@ def test_trusted_advisor_data(athena):
     data = athena_query(athena=athena, sql_query='SELECT * FROM "optimization_data"."trusted_advisor_data" LIMIT 10;')
     assert len(data) > 0, 'trusted_advisor_data is empty'
 
-def test_inventory_workspaces_metrics_data(athena):
-    data = athena_query(athena=athena, sql_query='SELECT * FROM "optimization_data"."inventory_workspaces_metrics_data" LIMIT 10;')
-    assert len(data) > 0, 'inventory_workspaces_metrics_data is empty'
+def test_workspaces_metrics_data(athena):
+    data = athena_query(athena=athena, sql_query='SELECT * FROM "optimization_data"."workspaces_metrics_data" LIMIT 10;')
+    assert len(data) > 0, 'workspaces_metrics_data is empty'
 
 def test_transit_gateway_data(athena):
     data = athena_query(athena=athena, sql_query='SELECT * FROM "optimization_data"."transit_gateway_data" LIMIT 10;')

--- a/test/test_from_scratch.py
+++ b/test/test_from_scratch.py
@@ -180,7 +180,7 @@ def test_compute_optimizer_export_triggered(compute_optimizer, start_time):
     jobs = compute_optimizer.describe_recommendation_export_jobs()['recommendationExportJobs']
     logger.debug(f'Jobs in: {jobs}')
     jobs_since_start = [job for job in jobs if job['creationTimestamp'].replace(tzinfo=None) > start_time.replace(tzinfo=None)]
-    assert len(jobs_since_start) == 7, f'started {len(jobs_since_start)} jobs. Expected 7. Not all jobs launched'
+    assert len(jobs_since_start) == 8, f'started {len(jobs_since_start)} jobs. Expected 8. Not all jobs launched'
     jobs_failed = [job for job in jobs_since_start if job.get('status') == 'failed']
     assert len(jobs_failed) == 0, f'Some jobs failed {jobs_failed}'
     # TODO: check how we can add better test, taking into account 15-30 mins delay of export in CO


### PR DESCRIPTION
## Summary
This PR implements a hybrid approach to IAM permissions in the "deploy-in-linked-account" template, replacing wildcard resources with specific ARN patterns where supported by AWS APIs while maintaining necessary wildcards only where required.

## Changes
- Replaced wildcard (`*`) resources with specific ARN patterns where supported
- Implemented resource-level permissions for EC2, RDS, ECS, WorkSpaces, and other services
- Added namespace conditions for CloudWatch metrics permissions
- Maintained wildcards only for APIs that don't support resource-level permissions
- Added clear documentation explaining each use of wildcards