### PR TITLE
Update EUC module functionality to use new state machine to give option to run against specific accounts or all accounts

### DIFF
--- a/data-collection/deploy/deploy-data-collection.yaml
+++ b/data-collection/deploy/deploy-data-collection.yaml
@@ -131,6 +131,7 @@ Mappings:
     main-v3:        {TemplatePath: cfn/data-collection/source/step-functions/main-state-machine-v3.json}
     crawler-v1:     {TemplatePath: cfn/data-collection/source/step-functions/crawler-state-machine-v1.json}
     standalone-v1:  {TemplatePath: cfn/data-collection/source/step-functions/awsfeeds-state-machine-v1.json}
+    euc-v1:         {TemplatePath: cfn/data-collection/source/step-functions/euc-accounts-state-machine-v1.json}
 
 Parameters:
   DestinationBucket:
@@ -1200,7 +1201,7 @@ Resources:
         LambdaAnalyticsARN: !GetAtt LambdaAnalytics.Arn
         AccountCollectorLambdaARN: !Sub "${AccountCollector.Outputs.LambdaFunctionARN}"
         CodeBucket: !If [ ProdCFNTemplateUsed, !FindInMap [RegionMap, !Ref "AWS::Region", CodeBucket], !Ref CFNSourceBucket ]
-        StepFunctionTemplate: !FindInMap [StepFunctionCode, main-v3, TemplatePath]
+        StepFunctionTemplate: !FindInMap [StepFunctionCode, euc-v1, TemplatePath]
         StepFunctionExecutionRoleARN: !GetAtt StepFunctionExecutionRole.Arn
         SchedulerExecutionRoleARN: !GetAtt SchedulerExecutionRole.Arn
         EUCAccountIDs: !Ref EUCAccountIDs

--- a/data-collection/deploy/module-workspaces-metrics.yaml
+++ b/data-collection/deploy/module-workspaces-metrics.yaml
@@ -227,7 +227,6 @@ Resources:
           METRIC_NAMESPACE = 'AWS/WorkSpaces'
           METRIC_PERIOD = 3600
           BATCH_SIZE = 100  # Number of workspaces to process in each batch
-          EUC_ACCOUNT_IDS = os.environ.get('EUC_ACCOUNT_IDS', '')
 
           logger = logging.getLogger(__name__)
           logger.setLevel(getattr(logging, os.environ.get('LOG_LEVEL', 'INFO').upper(), logging.INFO))
@@ -270,7 +269,6 @@ Resources:
                   "BundleId": workspace.get("BundleId", ""),
                   "DirectoryId": workspace.get("DirectoryId", ""),
                   "ComputerName": workspace.get("ComputerName", ""),
-                  "WorkspaceProperties": workspace.get("WorkspaceProperties", {})
               }
               # Flatten WorkspaceProperties into individual columns
               if "WorkspaceProperties" in workspace:
@@ -481,52 +479,15 @@ Resources:
 
           def lambda_handler(event, context):
               logger.info(f"Event: {event}")
-
-              # Check if we're using specific EUC accounts or processing from the event
-              if EUC_ACCOUNT_IDS and EUC_ACCOUNT_IDS.strip():
-                  # Process specific accounts provided in the environment variable
-                  euc_accounts = [account.strip() for account in EUC_ACCOUNT_IDS.split(',') if account.strip()]
-                  logger.info(f"Using specific EUC accounts: {euc_accounts}")
-
-                  # Get the payer_id from the event if available, otherwise use a default
-                  payer_id = "unknown"
-                  if 'account' in event:
-                      try:
-                          account = json.loads(event["account"])
-                          payer_id = account.get("payer_id", "unknown")
-                      except:
-                          pass
-
-                  # Process accounts in parallel with a thread pool
-                  with concurrent.futures.ThreadPoolExecutor(max_workers=min(10, len(euc_accounts))) as executor:
-                      future_to_account = {
-                          executor.submit(process_account, account_id, payer_id): account_id
-                          for account_id in euc_accounts
-                      }
-                      for future in concurrent.futures.as_completed(future_to_account):
-                          account_id = future_to_account[future]
-                          try:
-                              future.result()
-                              logger.info(f"Successfully processed account {account_id}")
-                          except Exception as e:
-                              logger.error(f"Error processing account {account_id}: {str(e)}")
-              elif 'account' in event:
-                  # Process the account from the event (original behavior)
-                  try:
-                      account = json.loads(event["account"])
-                      account_id = account["account_id"]
-                      payer_id = account["payer_id"]
-                      logger.info(f"Collecting data for account from event: {account_id}")
-                      process_account(account_id, payer_id)
-                  except Exception as e:
-                      logger.error(f"Error processing account from event: {str(e)}")
-                      raise
-              else:
-                  raise ValueError(
-                      "Please do not trigger this Lambda manually. "
-                      "Find the corresponding state machine in Step Functions and Trigger from there, "
-                      "or specify EUC_ACCOUNT_IDS environment variable."
-                  )
+              try:
+                  account = json.loads(event["account"])
+                  account_id = account["account_id"]
+                  payer_id = account["payer_id"]
+                  logger.info(f"Collecting data for account from event: {account_id}")
+                  process_account(account_id, payer_id)
+              except Exception as e:
+                  logger.error(f"Error processing account from event: {str(e)}")
+                  raise
               return "Successful"
 
           def process_account(account_id, payer_id):
@@ -584,7 +545,6 @@ Resources:
           ROLENAME: !Ref MultiAccountRoleName
           REGIONS: !Ref RegionsInScope
           ROLE_SESSION_NAME: data_collection
-          EUC_ACCOUNT_IDS: !Ref EUCAccountIDs
 
   LogGroup:
     Type: AWS::Logs::LogGroup
@@ -635,6 +595,10 @@ Resources:
       Target:
         Arn: !GetAtt ModuleStepFunction.Arn
         RoleArn: !Ref SchedulerExecutionRoleARN
+        Input: !Sub |
+          {
+            "eucAccountIds": "${EUCAccountIDs}"
+          }
 
   AnalyticsExecutor:
     Type: Custom::LambdaAnalyticsExecutor

--- a/data-collection/deploy/source/step-functions/euc-accounts-state-machine-v1.json
+++ b/data-collection/deploy/source/step-functions/euc-accounts-state-machine-v1.json
@@ -1,0 +1,176 @@
+{
+    "Comment": "Orchestrate the collection of WorkSpaces metrics data with EUC account handling",
+    "StartAt": "FormatEUCAccounts",
+    "States": {
+        "FormatEUCAccounts": {
+            "Type": "Pass",
+            "Parameters": {
+                "eucAccountIds.$": "$.eucAccountIds",
+                "euc_accounts.$": "States.StringSplit(States.JsonToString($.eucAccountIds), ',')"
+            },
+            "Next": "FilterEmptyAccounts"
+        },
+        "FilterEmptyAccounts": {
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "And": [
+                        {
+                            "Variable": "$.eucAccountIds",
+                            "IsPresent": true
+                        },
+                        {
+                            "Not": {
+                                "Variable": "$.eucAccountIds",
+                                "StringEquals": ""
+                            }
+                        }
+                    ],
+                    "Next": "ProcessEUCAccounts"
+                }
+            ],
+            "Default": "AccountCollectorInvoke"
+        },
+        "ProcessEUCAccounts": {
+            "Type": "Pass",
+            "Parameters": {
+                "accountLambdaOutput": {
+                    "Payload": {
+                        "accounts": {
+                            "account.$": "$.euc_accounts"
+                        }
+                    }
+                }
+            },
+            "Next": "AccountMapDirect"
+        },
+        "AccountCollectorInvoke": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "Parameters": {
+                "Payload": {
+                    "Type": "${CollectionType}"
+                },
+                "FunctionName": "${AccountCollectorLambdaARN}"
+            },
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "Lambda.ServiceException",
+                        "Lambda.AWSLambdaException",
+                        "Lambda.SdkClientException",
+                        "Lambda.TooManyRequestsException"
+                    ],
+                    "IntervalSeconds": 2,
+                    "MaxAttempts": 6,
+                    "BackoffRate": 2
+                }
+            ],
+            "Next": "AccountMapS3",
+            "ResultPath": "$.accountLambdaOutput"
+        },
+        "AccountMapDirect": {
+            "Type": "Map",
+            "ItemProcessor": {
+                "ProcessorConfig": {
+                    "Mode": "DISTRIBUTED",
+                    "ExecutionType": "STANDARD"
+                },
+                "StartAt": "InvokeModuleLambda",
+                "States": {
+                    "InvokeModuleLambda": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:states:${DeployRegion}:${Account}:lambda:invoke",
+                        "OutputPath": "$.Payload",
+                        "Parameters": {
+                            "Payload": {
+                                "account.$": "$.account",
+                                "params": "${Params}"
+                            },
+                            "FunctionName": "${ModuleLambdaARN}"
+                        },
+                        "Retry": [
+                            {
+                                "ErrorEquals": [
+                                    "Lambda.ServiceException",
+                                    "Lambda.AWSLambdaException",
+                                    "Lambda.SdkClientException",
+                                    "Lambda.TooManyRequestsException"
+                                ],
+                                "IntervalSeconds": 2,
+                                "MaxAttempts": 6,
+                                "BackoffRate": 2
+                            }
+                        ],
+                        "End": true
+                    }
+                }
+            },
+            "MaxConcurrency": 60,
+            "ItemsPath": "$.accountLambdaOutput.Payload.accounts.account",
+            "Next": "CrawlerStepFunctionStartExecution"
+        },
+        "AccountMapS3": {
+            "Type": "Map",
+            "ItemProcessor": {
+                "ProcessorConfig": {
+                    "Mode": "DISTRIBUTED",
+                    "ExecutionType": "STANDARD"
+                },
+                "StartAt": "InvokeModuleLambda",
+                "States": {
+                    "InvokeModuleLambda": {
+                        "Type": "Task",
+                        "Resource": "arn:aws:states:${DeployRegion}:${Account}:lambda:invoke",
+                        "OutputPath": "$.Payload",
+                        "Parameters": {
+                            "Payload": {
+                                "account.$": "$.account",
+                                "params": "${Params}"
+                            },
+                            "FunctionName": "${ModuleLambdaARN}"
+                        },
+                        "Retry": [
+                            {
+                                "ErrorEquals": [
+                                    "Lambda.ServiceException",
+                                    "Lambda.AWSLambdaException",
+                                    "Lambda.SdkClientException",
+                                    "Lambda.TooManyRequestsException"
+                                ],
+                                "IntervalSeconds": 2,
+                                "MaxAttempts": 6,
+                                "BackoffRate": 2
+                            }
+                        ],
+                        "End": true
+                    }
+                }
+            },
+            "MaxConcurrency": 60,
+            "ItemReader": {
+                "Resource": "arn:aws:states:::s3:getObject",
+                "ReaderConfig": {
+                    "InputType": "JSON"
+                },
+                "Parameters": {
+                    "Bucket.$": "$.accountLambdaOutput.Payload.bucket",
+                    "Key.$": "$.accountLambdaOutput.Payload.accountList"
+                }
+            },
+            "Next": "CrawlerStepFunctionStartExecution"
+        },
+        "CrawlerStepFunctionStartExecution": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::states:startExecution.sync:2",
+            "Parameters": {
+                "StateMachineArn": "arn:aws:states:${DeployRegion}:${Account}:stateMachine:${Prefix}CrawlerExecution-StateMachine",
+                "Input": {
+                    "crawlers": ${Crawlers}
+                }
+            },
+            "End": true
+        }
+    },
+    "TimeoutSeconds": 10800
+}


### PR DESCRIPTION
…f specific accounts that have workspaces deployed are specified in CF parameter (EUCAccountIDs) or run against all accounts within an Org. Tweaked Lambda code and removed a field which was causing a duplicate in athena table

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
